### PR TITLE
Bump base/bytestring lower bounds

### DIFF
--- a/kademlia.cabal
+++ b/kademlia.cabal
@@ -39,10 +39,10 @@ library
                        Network.Kademlia.ReplyQueue,
                        Network.Kademlia.Implementation
 
-  build-depends:       base >= 4 && < 5,
+  build-depends:       base >= 4.7 && < 5,
                        network >=2.6 && <2.7,
                        mtl >=2.1.3.1,
-                       bytestring >=0.10 && <0.11,
+                       bytestring >=0.10.2 && <0.11,
                        transformers >=0.3,
                        containers >=0.5.5.1,
                        stm >=2.4.3,


### PR DESCRIPTION
`Data.Bits.zeroBits` was added in GHC 7.8 and `Data.ByteString.Builder` in bytestring-0.10.2.0.

I've revised the current version https://hackage.haskell.org/package/kademlia/revisions/ so a new release is only needed if you wish to add backwards compatibility.
